### PR TITLE
Feat/engage http client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,10 @@
         "Engage\\": "src/"
       }
     },
-    "require": {}
+    "require": {
+        "symfony/http-client": "^4.4"
+    },
+    "require-dev":{
+        "phpunit/phpunit": "^7.5"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2121 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "67c87630f06e6975f28666699ed5faa3",
+    "packages": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-10T18:47:58+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T09:40:50+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/master"
+            },
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/master"
+            },
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
+                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/master"
+            },
+            "time": "2020-04-27T09:25:28+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "4.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/da3fd972d6bafd628114f7e7e036f45944b62e9c",
+                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
+                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "^1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpdocumentor/type-resolver": "0.4.*",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/release/4.x"
+            },
+            "time": "2019-12-28T18:55:12+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "^7.1",
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/0.7.2"
+            },
+            "time": "2019-08-22T18:11:29+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5 || ^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/v1.10.3"
+            },
+            "time": "2020-03-05T15:02:03+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "6.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^2.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/master"
+            },
+            "time": "2018-10-31T16:06:48+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:25:21+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+            },
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:20:02+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
+                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2020-11-30T08:38:46+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "7.5.20",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.7",
+                "phar-io/manifest": "^1.0.2",
+                "phar-io/version": "^2.0",
+                "php": "^7.1",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-file-iterator": "^2.0.1",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1",
+                "sebastian/comparator": "^3.0",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^4.0",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "conflict": {
+                "phpunit/phpunit-mock-objects": "*"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/7.5.20"
+            },
+            "time": "2020-01-08T08:45:45+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/master"
+            },
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.3"
+            },
+            "time": "2020-03-23T09:12:05+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:04:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:59:04+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "4.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:53:42+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:47:53+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/2.0.0"
+            },
+            "time": "2017-04-27T15:39:26+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:40:27+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:37:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:34:24+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:30:19+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/master"
+            },
+            "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v4.4.19",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "d8df50fe9229576b254c6822eb5cfff36c02c967"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/d8df50fe9229576b254c6822eb5cfff36c02c967",
+                "reference": "d8df50fe9229576b254c6822eb5cfff36c02c967",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "psr/log": "^1.0",
+                "symfony/http-client-contracts": "^1.1.10|^2",
+                "symfony/polyfill-php73": "^1.11",
+                "symfony/service-contracts": "^1.0|^2"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "1.1"
+            },
+            "require-dev": {
+                "guzzlehttp/promises": "^1.4",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/dependency-injection": "^4.3|^5.0",
+                "symfony/http-kernel": "^4.4.13",
+                "symfony/process": "^4.2|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v4.4.19"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-27T09:09:26+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v1.1.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "7e86f903f9720d0caa7688f5c29a2de2d77cbb89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/7e86f903f9720d0caa7688f5c29a2de2d77cbb89",
+                "reference": "7e86f903f9720d0caa7688f5c29a2de2d77cbb89",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3"
+            },
+            "suggest": {
+                "symfony/http-client-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v1.1.10"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-17T09:35:39+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.22.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.22.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v1.1.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "b776d18b303a39f56c63747bcb977ad4b27aca26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b776d18b303a39f56c63747bcb977ad4b27aca26",
+                "reference": "b776d18b303a39f56c63747bcb977ad4b27aca26",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v1.1.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-06T13:19:58+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/master"
+            },
+            "time": "2019-06-13T22:48:21+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
+            },
+            "time": "2020-07-08T17:02:28+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+  backupStaticAttributes="false"
+  bootstrap="vendor/autoload.php"
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  processIsolation="false"
+  stopOnFailure="false"
+  >
+<testsuites>
+  <testsuite name="Package Test Suite">
+    <directory suffix=".php">./tests/</directory>
+  </testsuite>
+</testsuites>
+</phpunit>

--- a/src/EngageClient.php
+++ b/src/EngageClient.php
@@ -5,12 +5,21 @@ class EngageClient
 {
 
   private $resourceFactory;
-  
+  public $key;
+  public $secret;
+
   public function __construct($key = null, $secret = null)
   {
     if (!$key) {
       throw new \InvalidArgumentException('API key not added.');
     }
+
+    if (!$secret) {
+      throw new \InvalidArgumentException('API secret key not added.');
+    }
+
+    $this->key = $key;
+    $this->secret = $secret;
   }
 
   public function __get($name)

--- a/src/EngageClient.php
+++ b/src/EngageClient.php
@@ -1,34 +1,33 @@
 <?php
+
 namespace Engage;
 
 class EngageClient
 {
+    private $resourceFactory;
+    public $key;
+    public $secret;
 
-  private $resourceFactory;
-  public $key;
-  public $secret;
+    public function __construct($key = null, $secret = null)
+    {
+        if (!$key) {
+            throw new \InvalidArgumentException('API key not added.');
+        }
 
-  public function __construct($key = null, $secret = null)
-  {
-    if (!$key) {
-      throw new \InvalidArgumentException('API key not added.');
+        if (!$secret) {
+            throw new \InvalidArgumentException('API secret key not added.');
+        }
+
+        $this->key = $key;
+        $this->secret = $secret;
     }
 
-    if (!$secret) {
-      throw new \InvalidArgumentException('API secret key not added.');
+    public function __get($name)
+    {
+        if (null === $this->resourceFactory) {
+            $this->resourceFactory = new \Engage\ResourceFactory($this);
+        }
+
+        return $this->resourceFactory->__get($name);
     }
-
-    $this->key = $key;
-    $this->secret = $secret;
-  }
-
-  public function __get($name)
-  {
-    if (null === $this->resourceFactory) {
-      $this->resourceFactory = new \Engage\ResourceFactory($this);
-    }
-
-    return $this->resourceFactory->__get($name);
-  }
 }
-?>

--- a/src/ResourceFactory.php
+++ b/src/ResourceFactory.php
@@ -1,27 +1,29 @@
 <?php
+
 namespace Engage;
 
 use Engage\Resources\Users as Users;
 
 class ResourceFactory
 {
-  private $clientObj;
-  private $resources = [
-    'users' => Users::class
+    private $clientObj;
+    private $resources = [
+    'users' => Users::class,
   ];
 
-  public function __construct($clientObj) {
-    $this->clientObj = $clientObj;
-  }
-
-  public function __get($name)
-  {
-    if (!array_key_exists($name, $this->resources)) {
-      throw new \InvalidArgumentException("The resource $name is not valid.");
+    public function __construct($clientObj)
+    {
+        $this->clientObj = $clientObj;
     }
 
-    $class = $this->resources[$name];
-    return new $class($this->clientObj);
-  }
+    public function __get($name)
+    {
+        if (!array_key_exists($name, $this->resources)) {
+            throw new \InvalidArgumentException("The resource $name is not valid.");
+        }
+
+        $class = $this->resources[$name];
+
+        return new $class($this->clientObj);
+    }
 }
-?>

--- a/src/ResourceFactory.php
+++ b/src/ResourceFactory.php
@@ -5,19 +5,23 @@ use Engage\Resources\Users as Users;
 
 class ResourceFactory
 {
-  
+  private $clientObj;
   private $resources = [
     'users' => Users::class
   ];
-  
+
+  public function __construct($clientObj) {
+    $this->clientObj = $clientObj;
+  }
+
   public function __get($name)
   {
     if (!array_key_exists($name, $this->resources)) {
       throw new \InvalidArgumentException("The resource $name is not valid.");
     }
-    
+
     $class = $this->resources[$name];
-    return new $class;
+    return new $class($this->clientObj);
   }
 }
 ?>

--- a/src/resources/Api.php
+++ b/src/resources/Api.php
@@ -50,7 +50,6 @@ class Api
   {
   $endpoint = self::ROOT . $url;
   $payload = $this->preparePayload($params);
-  var_dump($payload);
   try {
     $response = $this->client->request($method, $endpoint, $payload);
     $code = $response->getStatusCode();
@@ -86,6 +85,17 @@ class Api
       ],
       'json' => $params
     ];
+  }
+
+  // allow client be mocked during testing
+  public function setClient($client)
+  {
+    $this->client = $client;
+  }
+
+  public function getClient()
+  {
+    return $this->client;
   }
 
   public function setCredentials($clientObj)

--- a/src/resources/Api.php
+++ b/src/resources/Api.php
@@ -1,19 +1,97 @@
 <?php
 namespace Engage\Resources;
 
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\Exception\ClientException;
+use RuntimeException;
+
 class Api
 {
+  /**
+   * The Symfony HTTP client instance.
+   *
+   * @var \Symfony\Component\HttpClient\HttpClient
+   */
+  protected $client;
+
+  /**
+   * The Engage API Key
+   *
+   * @var string
+   */
+  protected $key;
+
+  /**
+   * The Engage API Secret Key
+   *
+   * @var string
+   */
+  protected $secret;
+
+  /**
+   * Engage API endpoint.
+   *
+   * @var string
+   */
   const ROOT = 'https://api.engage.so';
 
-  private function request() {
+  /**
+   * Instantiate a new API instance.
+   *
+   * @return void
+   */
+  public function __construct()
+  {
+    // initialize http client
+    $this->client = HttpClient::create();
   }
-  
-  public function put($url, $params) {
-    var_dump($params, $url);
+
+  public function makeRequest($method, $url, $body)
+  {
+  $endpoint = self::ROOT . $url;
+  $payload = $this->preparePayload($params);
+  var_dump($payload);
+  try {
+    $response = $this->client->request($method, $endpoint, $payload);
+    $code = $response->getStatusCode();
+
+    if ($code > 300) {
+      return json_decode($response->getContent(false));
+    }
+
+    return $response->getContent();
+  } catch (ClientException $e) {
+    throw new \Exception("API Connection error ". $e->getMessage());
   }
-  
-  public function post($url, $params) {
-    var_dump($params, $url);
+  }
+
+  public function put($url, $params)
+  {
+    $response = $this->makeRequest("PUT", $url, $params);
+    return $response;
+  }
+
+  public function post($url, $params)
+  {
+    $response = $this->makeRequest("POST", $url, $params);
+    return $response;
+  }
+
+  public function preparePayload($params) {
+    return [
+      'headers' => [
+        'User-Agent' => 'Engage.so PHP Client',
+        'Content-Type' => 'application/json',
+        'Authorization' => 'Basic '. base64_encode(sprintf("%s:%s", $this->key, $this->secret))
+      ],
+      'json' => $params
+    ];
+  }
+
+  public function setCredentials($clientObj)
+  {
+    $this->key = $clientObj->key;
+    $this->secret = $clientObj->secret;
   }
 }
 ?>

--- a/src/resources/Api.php
+++ b/src/resources/Api.php
@@ -1,107 +1,109 @@
 <?php
+
 namespace Engage\Resources;
 
-use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpClient\Exception\ClientException;
-use RuntimeException;
+use Symfony\Component\HttpClient\HttpClient;
 
 class Api
 {
-  /**
-   * The Symfony HTTP client instance.
-   *
-   * @var \Symfony\Component\HttpClient\HttpClient
-   */
-  protected $client;
+    /**
+     * The Symfony HTTP client instance.
+     *
+     * @var \Symfony\Component\HttpClient\HttpClient
+     */
+    protected $client;
 
-  /**
-   * The Engage API Key
-   *
-   * @var string
-   */
-  protected $key;
+    /**
+     * The Engage API Key.
+     *
+     * @var string
+     */
+    protected $key;
 
-  /**
-   * The Engage API Secret Key
-   *
-   * @var string
-   */
-  protected $secret;
+    /**
+     * The Engage API Secret Key.
+     *
+     * @var string
+     */
+    protected $secret;
 
-  /**
-   * Engage API endpoint.
-   *
-   * @var string
-   */
-  const ROOT = 'https://api.engage.so';
+    /**
+     * Engage API endpoint.
+     *
+     * @var string
+     */
+    const ROOT = 'https://api.engage.so';
 
-  /**
-   * Instantiate a new API instance.
-   *
-   * @return void
-   */
-  public function __construct()
-  {
-    // initialize http client
-    $this->client = HttpClient::create();
-  }
-
-  public function makeRequest($method, $url, $body)
-  {
-  $endpoint = self::ROOT . $url;
-  $payload = $this->preparePayload($params);
-  try {
-    $response = $this->client->request($method, $endpoint, $payload);
-    $code = $response->getStatusCode();
-
-    if ($code > 300) {
-      return json_decode($response->getContent(false));
+    /**
+     * Instantiate a new API instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        // initialize http client
+        $this->client = HttpClient::create();
     }
 
-    return $response->getContent();
-  } catch (ClientException $e) {
-    throw new \Exception("API Connection error ". $e->getMessage());
-  }
-  }
+    public function makeRequest($method, $url, $body)
+    {
+        $endpoint = self::ROOT.$url;
+        $payload = $this->preparePayload($params);
+        try {
+            $response = $this->client->request($method, $endpoint, $payload);
+            $code = $response->getStatusCode();
 
-  public function put($url, $params)
-  {
-    $response = $this->makeRequest("PUT", $url, $params);
-    return $response;
-  }
+            if ($code > 300) {
+                return json_decode($response->getContent(false));
+            }
 
-  public function post($url, $params)
-  {
-    $response = $this->makeRequest("POST", $url, $params);
-    return $response;
-  }
+            return $response->getContent();
+        } catch (ClientException $e) {
+            throw new \Exception('API Connection error '.$e->getMessage());
+        }
+    }
 
-  public function preparePayload($params) {
-    return [
-      'headers' => [
-        'User-Agent' => 'Engage.so PHP Client',
-        'Content-Type' => 'application/json',
-        'Authorization' => 'Basic '. base64_encode(sprintf("%s:%s", $this->key, $this->secret))
-      ],
-      'json' => $params
-    ];
-  }
+    public function put($url, $params)
+    {
+        $response = $this->makeRequest('PUT', $url, $params);
 
-  // allow client be mocked during testing
-  public function setClient($client)
-  {
-    $this->client = $client;
-  }
+        return $response;
+    }
 
-  public function getClient()
-  {
-    return $this->client;
-  }
+    public function post($url, $params)
+    {
+        $response = $this->makeRequest('POST', $url, $params);
 
-  public function setCredentials($clientObj)
-  {
-    $this->key = $clientObj->key;
-    $this->secret = $clientObj->secret;
-  }
+        return $response;
+    }
+
+    public function preparePayload($params)
+    {
+        return [
+          'json' => $params,
+          'headers' => [
+            'User-Agent' => 'Engage.so PHP Client',
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Basic '.base64_encode(sprintf('%s:%s', $this->key, $this->secret)),
+          ],
+      ];
+    }
+
+    // allow client be mocked during testing
+    public function setClient($client)
+    {
+        $this->client = $client;
+    }
+
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    public function setCredentials($clientObj)
+    {
+        $this->key = $clientObj->key;
+        $this->secret = $clientObj->secret;
+    }
 }
-?>

--- a/src/resources/Users.php
+++ b/src/resources/Users.php
@@ -73,9 +73,5 @@ class Users extends Api
 
     return $this->post("/users/$uid/events", data);
   }
-
-  public function test() {
-    return $this->put("/users/test", []);
-  }
 }
 ?>

--- a/src/resources/Users.php
+++ b/src/resources/Users.php
@@ -4,6 +4,11 @@ namespace Engage\Resources;
 class Users extends Api
 {
 
+  public function __construct($clientObj) {
+    parent::__construct();
+    $this->setCredentials($clientObj);
+  }
+
   public function identify($o = null) {
     if (!$o) {
       throw new \InvalidArgumentException('You need to pass an object with at least an id and email.');
@@ -11,7 +16,7 @@ class Users extends Api
     if (!$o['id']) {
       throw new \InvalidArgumentException('ID missing.');
     }
-    if (!$o['email'] || preg_match('/^\S+@\S+$/', $o['email'])) {
+    if (!$o['email'] || !preg_match('/^\S+@\S+$/', $o['email'])) {
       throw new \InvalidArgumentException('Email missing or invalid.');
     }
     $allowed = ['id', 'email', 'device_token', 'device_platform', 'number', 'created_at', 'first_name', 'last_name'];
@@ -21,7 +26,7 @@ class Users extends Api
         $params[k] = $v;
       }
     }
-  
+
     return $this->put("/users/{$o['id']}", $params);
   }
 
@@ -44,7 +49,7 @@ class Users extends Api
         $params['meta'][$k] = $v;
       }
     }
-  
+
     return $this->put("/users/$uid", params);
   }
 
@@ -65,8 +70,12 @@ class Users extends Api
         throw new \InvalidArgumentException('No attributes provided');
       }
     }
-  
+
     return $this->post("/users/$uid/events", data);
+  }
+
+  public function test() {
+    return $this->put("/users/test", []);
   }
 }
 ?>

--- a/src/resources/Users.php
+++ b/src/resources/Users.php
@@ -1,77 +1,80 @@
 <?php
+
 namespace Engage\Resources;
 
 class Users extends Api
 {
-
-  public function __construct($clientObj) {
-    parent::__construct();
-    $this->setCredentials($clientObj);
-  }
-
-  public function identify($o = null) {
-    if (!$o) {
-      throw new \InvalidArgumentException('You need to pass an object with at least an id and email.');
-    }
-    if (!$o['id']) {
-      throw new \InvalidArgumentException('ID missing.');
-    }
-    if (!$o['email'] || !preg_match('/^\S+@\S+$/', $o['email'])) {
-      throw new \InvalidArgumentException('Email missing or invalid.');
-    }
-    $allowed = ['id', 'email', 'device_token', 'device_platform', 'number', 'created_at', 'first_name', 'last_name'];
-    $params = [];
-    foreach ($o as $k => $v) {
-      if ($allowed[$k]) {
-        $params[k] = $v;
-      }
+    public function __construct($clientObj)
+    {
+        parent::__construct();
+        $this->setCredentials($clientObj);
     }
 
-    return $this->put("/users/{$o['id']}", $params);
-  }
+    public function identify($o = null)
+    {
+        if (!$o) {
+            throw new \InvalidArgumentException('You need to pass an object with at least an id and email.');
+        }
+        if (!$o['id']) {
+            throw new \InvalidArgumentException('ID missing.');
+        }
+        if (!$o['email'] || !preg_match('/^\S+@\S+$/', $o['email'])) {
+            throw new \InvalidArgumentException('Email missing or invalid.');
+        }
+        $allowed = ['id', 'email', 'device_token', 'device_platform', 'number', 'created_at', 'first_name', 'last_name'];
+        $params = [];
+        foreach ($o as $k => $v) {
+            if ($allowed[$k]) {
+                $params[k] = $v;
+            }
+        }
 
-  public function addAttribute($uid, $data) {
-    if (!$uid) {
-      throw new \InvalidArgumentException('User id missing.');
-    }
-    if (!$data || !is_array($data)) {
-      throw new \InvalidArgumentException('Attributes missing.');
-    }
-    if (!count($data)) {
-      throw new \InvalidArgumentException('No attributes provided.');
-    }
-    $notMeta = ['email', 'device_token', 'device_platform', 'number', 'created_at', 'first_name', 'last_name'];
-    $params = ['meta' => []];
-    foreach ($data as $k => $v) {
-      if ($notMeta[$k]) {
-        $params[$k] = $v;
-      } else {
-        $params['meta'][$k] = $v;
-      }
-    }
-
-    return $this->put("/users/$uid", params);
-  }
-
-  public function track($uid, $data) {
-    if (!$uid) {
-      throw new \InvalidArgumentException('User id missing');
-    }
-    if (!$data) {
-      throw new \InvalidArgumentException('Attributes missing');
-    }
-    if (is_string($data)) {
-      $data = [
-        'event' => data,
-        'value' => true
-      ];
-    } else {
-      if (!count($data)) {
-        throw new \InvalidArgumentException('No attributes provided');
-      }
+        return $this->put("/users/{$o['id']}", $params);
     }
 
-    return $this->post("/users/$uid/events", data);
-  }
+    public function addAttribute($uid, $data)
+    {
+        if (!$uid) {
+            throw new \InvalidArgumentException('User id missing.');
+        }
+        if (!$data || !is_array($data)) {
+            throw new \InvalidArgumentException('Attributes missing.');
+        }
+        if (!count($data)) {
+            throw new \InvalidArgumentException('No attributes provided.');
+        }
+        $notMeta = ['email', 'device_token', 'device_platform', 'number', 'created_at', 'first_name', 'last_name'];
+        $params = ['meta' => []];
+        foreach ($data as $k => $v) {
+            if ($notMeta[$k]) {
+                $params[$k] = $v;
+            } else {
+                $params['meta'][$k] = $v;
+            }
+        }
+
+        return $this->put("/users/$uid", params);
+    }
+
+    public function track($uid, $data)
+    {
+        if (!$uid) {
+            throw new \InvalidArgumentException('User id missing');
+        }
+        if (!$data) {
+            throw new \InvalidArgumentException('Attributes missing');
+        }
+        if (is_string($data)) {
+            $data = [
+              'event' => data,
+              'value' => true,
+            ];
+        } else {
+            if (!count($data)) {
+                throw new \InvalidArgumentException('No attributes provided');
+            }
+        }
+
+        return $this->post("/users/$uid/events", data);
+    }
 }
-?>

--- a/tests/APITest.php
+++ b/tests/APITest.php
@@ -1,80 +1,78 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-use Engage\Resources\Api;
 use Engage\EngageClient;
+use Engage\Resources\Api;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
 class APITest extends TestCase
 {
-  protected $defaultAuth = "Basic a2V5OnNlY3JldA==";
+    protected $defaultAuth = 'Basic a2V5OnNlY3JldA==';
 
-  public function testApiHttpClientIsInitialized()
-  {
-    $api = new Api();
+    public function testApiHttpClientIsInitialized()
+    {
+        $api = new Api();
 
-    $this->assertInstanceOf(CurlHttpClient::class, $api->getClient());
-  }
+        $this->assertInstanceOf(CurlHttpClient::class, $api->getClient());
+    }
 
-  public function testPayloadContentsRequiredData()
-  {
-    $client = new EngageClient('key', 'secret');
-    $api = new Api();
-    $api->setCredentials($client);
+    public function testPayloadContentsRequiredData()
+    {
+        $client = new EngageClient('key', 'secret');
+        $api = new Api();
+        $api->setCredentials($client);
 
-    $data = [
-      'email' => 'test@email.com',
-      'meta' => []
-    ];
-    $payload = $api->preparePayload($data);
+        $data = [
+          'email' => 'test@email.com',
+          'meta' => [],
+        ];
+        $payload = $api->preparePayload($data);
 
-    $this->assertSame($payload['headers']['Authorization'], $this->defaultAuth);
-    $this->assertSame($payload['headers']['Content-Type'], 'application/json');
-    $this->assertSame($payload['json'], $data);
-  }
+        $this->assertSame($payload['headers']['Authorization'], $this->defaultAuth);
+        $this->assertSame($payload['headers']['Content-Type'], 'application/json');
+        $this->assertSame($payload['json'], $data);
+    }
 
-  public function testCanMakeRequest()
-  {
-    $client = new EngageClient('key', 'secret');
-    $api = new Api();
-    $api->setCredentials($client);
+    public function testCanMakeRequest()
+    {
+        $client = new EngageClient('key', 'secret');
+        $api = new Api();
+        $api->setCredentials($client);
 
-    $data = [
-      'email' => 'test@email.com',
-      'meta' => []
-    ];
+        $data = [
+          'email' => 'test@email.com',
+          'meta' => [],
+        ];
 
-    $clientStub = $this->getStubbedClient(['status' => 'ok']);
-    $api->setClient($clientStub);
-    $resp = $api->put("/users/1234", $data);
+        $clientStub = $this->getStubbedClient(['status' => 'ok']);
+        $api->setClient($clientStub);
+        $resp = $api->put('/users/1234', $data);
 
-    $this->assertSame("ok", $resp);
-  }
+        $this->assertSame('ok', $resp);
+    }
 
-  public function testCanMakeFailingRequest()
-  {
-    $client = new EngageClient('key', 'secret');
-    $api = new Api();
-    $api->setCredentials($client);
+    public function testCanMakeFailingRequest()
+    {
+        $client = new EngageClient('key', 'secret');
+        $api = new Api();
+        $api->setCredentials($client);
 
+        $data = ['email' => 'test@email.com', 'id' => '1234'];
+        $response = new MockResponse([json_encode(['error' => 'Unauthorized'])], ['http_code' => 403]);
+        $clientStub = new MockHttpClient($response);
+        $api->setClient($clientStub);
+        $resp = $api->post('/users/1234', $data);
 
-    $data = ['email' => 'test@email.com', 'id' => '1234'];
-    $response = new MockResponse([json_encode(['error' => 'Unauthorized'])], ['http_code' => 403]);
-    $clientStub = new MockHttpClient($response);
-    $api->setClient($clientStub);
-    $resp = $api->post("/users/1234", $data);
+        $this->assertSame('Unauthorized', $resp->error);
+    }
 
-    $this->assertSame("Unauthorized", $resp->error);
+    public function getStubbedClient($body)
+    {
+        $response = new MockResponse($body);
+        $client = new MockHttpClient($response);
 
-  }
-
-  public function getStubbedClient($body)
-  {
-    $response = new MockResponse($body);
-    $client = new MockHttpClient($response);
-
-    return $client;
-  }
+        return $client;
+    }
 }

--- a/tests/APITest.php
+++ b/tests/APITest.php
@@ -1,0 +1,80 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Engage\Resources\Api;
+use Engage\EngageClient;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class APITest extends TestCase
+{
+  protected $defaultAuth = "Basic a2V5OnNlY3JldA==";
+
+  public function testApiHttpClientIsInitialized()
+  {
+    $api = new Api();
+
+    $this->assertInstanceOf(CurlHttpClient::class, $api->getClient());
+  }
+
+  public function testPayloadContentsRequiredData()
+  {
+    $client = new EngageClient('key', 'secret');
+    $api = new Api();
+    $api->setCredentials($client);
+
+    $data = [
+      'email' => 'test@email.com',
+      'meta' => []
+    ];
+    $payload = $api->preparePayload($data);
+
+    $this->assertSame($payload['headers']['Authorization'], $this->defaultAuth);
+    $this->assertSame($payload['headers']['Content-Type'], 'application/json');
+    $this->assertSame($payload['json'], $data);
+  }
+
+  public function testCanMakeRequest()
+  {
+    $client = new EngageClient('key', 'secret');
+    $api = new Api();
+    $api->setCredentials($client);
+
+    $data = [
+      'email' => 'test@email.com',
+      'meta' => []
+    ];
+
+    $clientStub = $this->getStubbedClient(['status' => 'ok']);
+    $api->setClient($clientStub);
+    $resp = $api->put("/users/1234", $data);
+
+    $this->assertSame("ok", $resp);
+  }
+
+  public function testCanMakeFailingRequest()
+  {
+    $client = new EngageClient('key', 'secret');
+    $api = new Api();
+    $api->setCredentials($client);
+
+
+    $data = ['email' => 'test@email.com', 'id' => '1234'];
+    $response = new MockResponse([json_encode(['error' => 'Unauthorized'])], ['http_code' => 403]);
+    $clientStub = new MockHttpClient($response);
+    $api->setClient($clientStub);
+    $resp = $api->post("/users/1234", $data);
+
+    $this->assertSame("Unauthorized", $resp->error);
+
+  }
+
+  public function getStubbedClient($body)
+  {
+    $response = new MockResponse($body);
+    $client = new MockHttpClient($response);
+
+    return $client;
+  }
+}

--- a/tests/EngageClientFunctionalTest.php
+++ b/tests/EngageClientFunctionalTest.php
@@ -5,75 +5,75 @@ use PHPUnit\Framework\TestCase;
 
 class EngageClientFunctionalTest extends TestCase
 {
-  protected $key;
-  protected $secret;
-  protected $client;
+    protected $key;
+    protected $secret;
+    protected $client;
 
-  protected $id = '1234';
-  protected $email = 'test@email.com';
-  protected $users;
-  protected $okStatus = ['status' => 'ok'];
+    protected $id = '1234';
+    protected $email = 'test@email.com';
+    protected $users;
+    protected $okStatus = ['status' => 'ok'];
 
-  // @skip
-  protected function setUp()
-  {
-    $this->key = $_SERVER["ENGAGE_KEY"];
-    $this->secret = $_SERVER["ENGAGE_SECRET"];
-    $skip = $_SERVER["ENGAGE_PHP_SKIP_INTEGRATION"];
+    // @skip
+    protected function setUp()
+    {
+        $this->key = $_SERVER['ENGAGE_KEY'];
+        $this->secret = $_SERVER['ENGAGE_SECRET'];
+        $skip = $_SERVER['ENGAGE_PHP_SKIP_INTEGRATION'];
 
-    if ($skip == "") {
-      $this->markTestSkipped(
-        'Set ENGAGE_KEY and ENGAGE_SECRET environment variables to enable integration testing'
-      );
+        if ($skip == '') {
+            $this->markTestSkipped(
+                'Set ENGAGE_KEY and ENGAGE_SECRET environment variables to enable integration testing'
+            );
+        }
+
+        $this->client = new EngageClient($this->key, $this->secret);
+        $this->users = $this->client->users;
     }
 
-    $this->client = new EngageClient($this->key, $this->secret);
-    $this->users = $this->client->users;
-  }
+    public function testIdentifyUsers()
+    {
+        $resp = $this->users->identify([
+            'id' => $this->id,
+            'email' => $this->email,
+        ]);
 
-  public function testIdentifyUsers()
-  {
-    $resp = $this->users->identify([
-      'id' => $this->id,
-      'email' => $this->email
-    ]);
+        $this->assertSame($this->okStatus, json_encode($resp));
+    }
 
-    $this->assertSame($this->okStatus, json_encode($resp));
-  }
+    public function testAddAttribute()
+    {
+        $resp = $this->users->addAttribute($this->id, [
+            'first_name' => 'Opeyemi',
+            'active' => true,
+            'created_at' => '2021-02-08',
+        ]);
 
-  public function testAddAttribute()
-  {
-    $resp = $this->users->addAttribute($this->id, [
-      'first_name' => 'Opeyemi',
-      'active' => true,
-      'created_at' => '2021-02-08'
-    ]);
+        $this->assertSame($this->okStatus, json_encode($resp));
+    }
 
-    $this->assertSame($this->okStatus, json_encode($resp));
-  }
+    public function testTrackUserEvent()
+    {
+        $resp = $this->users->track($this->id, [
+            'event' => 'Withdrawal',
+            'value' => 190.23,
+        ]);
 
-  public function testTrackUserEvent()
-  {
-    $resp = $this->users->track($this->id, [
-      'event' => 'Withdrawal',
-      'value' => 190.23
-    ]);
+        $this->assertSame($this->okStatus, json_encode($resp));
+    }
 
-    $this->assertSame($this->okStatus, json_encode($resp));
-  }
+    public function testTrackWithExtraPayload()
+    {
+        $resp = $this->users->track($this->id, [
+            'event' => 'Add to cart',
+            'timestamp' => '2020-05-30T09:30:10Z',
+            'properties' => [
+                'product' => 'T123',
+                'currency' => 'USD',
+                'amount' => 12.99,
+            ],
+        ]);
 
-  public function testTrackWithExtraPayload()
-  {
-    $resp = $this->users->track($this->id, [
-      "event" => "Add to cart",
-      "timestamp" => "2020-05-30T09:30:10Z",
-      "properties" => [
-        "product"=> "T123",
-        "currency"=> "USD",
-        "amount"=> 12.99
-      ]
-    ]);
-
-    $this->assertSame($this->okStatus, json_encode($resp));
-  }
+        $this->assertSame($this->okStatus, json_encode($resp));
+    }
 }

--- a/tests/EngageClientFunctionalTest.php
+++ b/tests/EngageClientFunctionalTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Engage\EngageClient;
+use PHPUnit\Framework\TestCase;
+
+class EngageClientFunctionalTest extends TestCase
+{
+  protected $key;
+  protected $secret;
+  protected $client;
+
+  protected $id = '1234';
+  protected $email = 'test@email.com';
+  protected $users;
+  protected $okStatus = ['status' => 'ok'];
+
+  // @skip
+  protected function setUp()
+  {
+    $this->key = $_SERVER["ENGAGE_KEY"];
+    $this->secret = $_SERVER["ENGAGE_SECRET"];
+    $skip = $_SERVER["ENGAGE_PHP_SKIP_INTEGRATION"];
+
+    if ($skip == "") {
+      $this->markTestSkipped(
+        'Set ENGAGE_KEY and ENGAGE_SECRET environment variables to enable integration testing'
+      );
+    }
+
+    $this->client = new EngageClient($this->key, $this->secret);
+    $this->users = $this->client->users;
+  }
+
+  public function testIdentifyUsers()
+  {
+    $resp = $this->users->identify([
+      'id' => $this->id,
+      'email' => $this->email
+    ]);
+
+    $this->assertSame($this->okStatus, json_encode($resp));
+  }
+
+  public function testAddAttribute()
+  {
+    $resp = $this->users->addAttribute($this->id, [
+      'first_name' => 'Opeyemi',
+      'active' => true,
+      'created_at' => '2021-02-08'
+    ]);
+
+    $this->assertSame($this->okStatus, json_encode($resp));
+  }
+
+  public function testTrackUserEvent()
+  {
+    $resp = $this->users->track($this->id, [
+      'event' => 'Withdrawal',
+      'value' => 190.23
+    ]);
+
+    $this->assertSame($this->okStatus, json_encode($resp));
+  }
+
+  public function testTrackWithExtraPayload()
+  {
+    $resp = $this->users->track($this->id, [
+      "event" => "Add to cart",
+      "timestamp" => "2020-05-30T09:30:10Z",
+      "properties" => [
+        "product"=> "T123",
+        "currency"=> "USD",
+        "amount"=> 12.99
+      ]
+    ]);
+
+    $this->assertSame($this->okStatus, json_encode($resp));
+  }
+}

--- a/tests/EngageClientUnitTest.php
+++ b/tests/EngageClientUnitTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use Engage\EngageClient;
+use Engage\Resources\Users;
+use PHPUnit\Framework\TestCase;
+
+class EngageClientUnitTest extends TestCase
+{
+  protected $client;
+  protected $key = "key";
+  protected $secret = "secret";
+  protected $id = '1071dfc';
+
+  // @group ClientInitialization
+  public function testClientInstantationIsSuccessful()
+  {
+    $client = new EngageClient($this->key, $this->secret);
+
+    $this->assertInstanceOf(EngageClient::class, $client);
+  }
+
+  // @group ClientInitialization
+  public function testShouldThrowIfNoParams()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    $client = new EngageClient();
+  }
+
+  // @group ClientInitialization
+  public function testShouldThrowIfEmptyArray()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    $client = new EngageClient([]);
+  }
+
+  public function testResourceFactoryIsRetrievable()
+  {
+    $client = new EngageClient($this->key, $this->secret);
+    $userResource = $client->users;
+
+    $this->assertInstanceOf(Users::class, $userResource);
+  }
+
+  // @group Identify
+  public function testIdentifyNoParameterPassed()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    $client = new EngageClient($this->key, $this->secret);
+    $data = $client->users->identify();
+  }
+
+  // @group Identify
+  public function testIdentifyEmptyArrayPassed()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    $client = new EngageClient($this->key, $this->secret);
+    $data = $client->users->identify([]);
+  }
+
+  // @group Identify
+  public function testIdentifyThrowIfNoEmail()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    $client = new EngageClient($this->key, $this->secret);
+    $data = $client->users->identify(['id' => $this->id]);
+  }
+
+  // @group Identify
+  public function testIdentifyThrowIfInvalidEmail()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    $client = new EngageClient($this->key, $this->secret);
+    $data = $client->users->identify(['id' => $this->id, 'email' => 'invalid']);
+  }
+
+  // @group AddAttribute
+  public function testAddAttributeThrowNoParameters()
+  {
+    $this->expectException(\ArgumentCountError::class);
+
+    $client = new EngageClient($this->key, $this->secret);
+    $data = $client->users->addAttribute();
+  }
+
+  // @group AddAttribute
+  public function testAddAttributeThrowNoDataAtrrPassed()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    $client = new EngageClient($this->key, $this->secret);
+    $data = $client->users->addAttribute($this->id, null);
+  }
+
+  // @group AddAttribute
+  public function testAddAttributeThrowEmptyDataPassed()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    $client = new EngageClient($this->key, $this->secret);
+    $data = $client->users->addAttribute($this->id, []);
+  }
+
+  // @group Track
+  public function testTrackShouldThrowNoParameter()
+  {
+    $this->expectException(\ArgumentCountError::class);
+
+    $client = new EngageClient($this->key, $this->secret);
+    $data = $client->users->track();
+  }
+
+  // @group Track
+  public function testTrackThrowNoDataAtrrPassed()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    $client = new EngageClient($this->key, $this->secret);
+    $data = $client->users->track($this->id, null);
+  }
+}

--- a/tests/EngageClientUnitTest.php
+++ b/tests/EngageClientUnitTest.php
@@ -6,121 +6,121 @@ use PHPUnit\Framework\TestCase;
 
 class EngageClientUnitTest extends TestCase
 {
-  protected $client;
-  protected $key = "key";
-  protected $secret = "secret";
-  protected $id = '1071dfc';
+    protected $client;
+    protected $key = 'key';
+    protected $secret = 'secret';
+    protected $id = '1071dfc';
 
-  // @group ClientInitialization
-  public function testClientInstantationIsSuccessful()
-  {
-    $client = new EngageClient($this->key, $this->secret);
+    // @group ClientInitialization
+    public function testClientInstantationIsSuccessful()
+    {
+        $client = new EngageClient($this->key, $this->secret);
 
-    $this->assertInstanceOf(EngageClient::class, $client);
-  }
+        $this->assertInstanceOf(EngageClient::class, $client);
+    }
 
-  // @group ClientInitialization
-  public function testShouldThrowIfNoParams()
-  {
-    $this->expectException(\InvalidArgumentException::class);
+    // @group ClientInitialization
+    public function testShouldThrowIfNoParams()
+    {
+        $this->expectException(\InvalidArgumentException::class);
 
-    $client = new EngageClient();
-  }
+        $client = new EngageClient();
+    }
 
-  // @group ClientInitialization
-  public function testShouldThrowIfEmptyArray()
-  {
-    $this->expectException(\InvalidArgumentException::class);
+    // @group ClientInitialization
+    public function testShouldThrowIfEmptyArray()
+    {
+        $this->expectException(\InvalidArgumentException::class);
 
-    $client = new EngageClient([]);
-  }
+        $client = new EngageClient([]);
+    }
 
-  public function testResourceFactoryIsRetrievable()
-  {
-    $client = new EngageClient($this->key, $this->secret);
-    $userResource = $client->users;
+    public function testResourceFactoryIsRetrievable()
+    {
+        $client = new EngageClient($this->key, $this->secret);
+        $userResource = $client->users;
 
-    $this->assertInstanceOf(Users::class, $userResource);
-  }
+        $this->assertInstanceOf(Users::class, $userResource);
+    }
 
-  // @group Identify
-  public function testIdentifyNoParameterPassed()
-  {
-    $this->expectException(\InvalidArgumentException::class);
+    // @group Identify
+    public function testIdentifyNoParameterPassed()
+    {
+        $this->expectException(\InvalidArgumentException::class);
 
-    $client = new EngageClient($this->key, $this->secret);
-    $data = $client->users->identify();
-  }
+        $client = new EngageClient($this->key, $this->secret);
+        $data = $client->users->identify();
+    }
 
-  // @group Identify
-  public function testIdentifyEmptyArrayPassed()
-  {
-    $this->expectException(\InvalidArgumentException::class);
+    // @group Identify
+    public function testIdentifyEmptyArrayPassed()
+    {
+        $this->expectException(\InvalidArgumentException::class);
 
-    $client = new EngageClient($this->key, $this->secret);
-    $data = $client->users->identify([]);
-  }
+        $client = new EngageClient($this->key, $this->secret);
+        $data = $client->users->identify([]);
+    }
 
-  // @group Identify
-  public function testIdentifyThrowIfNoEmail()
-  {
-    $this->expectException(\InvalidArgumentException::class);
+    // @group Identify
+    public function testIdentifyThrowIfNoEmail()
+    {
+        $this->expectException(\InvalidArgumentException::class);
 
-    $client = new EngageClient($this->key, $this->secret);
-    $data = $client->users->identify(['id' => $this->id]);
-  }
+        $client = new EngageClient($this->key, $this->secret);
+        $data = $client->users->identify(['id' => $this->id]);
+    }
 
-  // @group Identify
-  public function testIdentifyThrowIfInvalidEmail()
-  {
-    $this->expectException(\InvalidArgumentException::class);
+    // @group Identify
+    public function testIdentifyThrowIfInvalidEmail()
+    {
+        $this->expectException(\InvalidArgumentException::class);
 
-    $client = new EngageClient($this->key, $this->secret);
-    $data = $client->users->identify(['id' => $this->id, 'email' => 'invalid']);
-  }
+        $client = new EngageClient($this->key, $this->secret);
+        $data = $client->users->identify(['id' => $this->id, 'email' => 'invalid']);
+    }
 
-  // @group AddAttribute
-  public function testAddAttributeThrowNoParameters()
-  {
-    $this->expectException(\ArgumentCountError::class);
+    // @group AddAttribute
+    public function testAddAttributeThrowNoParameters()
+    {
+        $this->expectException(\ArgumentCountError::class);
 
-    $client = new EngageClient($this->key, $this->secret);
-    $data = $client->users->addAttribute();
-  }
+        $client = new EngageClient($this->key, $this->secret);
+        $data = $client->users->addAttribute();
+    }
 
-  // @group AddAttribute
-  public function testAddAttributeThrowNoDataAtrrPassed()
-  {
-    $this->expectException(\InvalidArgumentException::class);
+    // @group AddAttribute
+    public function testAddAttributeThrowNoDataAtrrPassed()
+    {
+        $this->expectException(\InvalidArgumentException::class);
 
-    $client = new EngageClient($this->key, $this->secret);
-    $data = $client->users->addAttribute($this->id, null);
-  }
+        $client = new EngageClient($this->key, $this->secret);
+        $data = $client->users->addAttribute($this->id, null);
+    }
 
-  // @group AddAttribute
-  public function testAddAttributeThrowEmptyDataPassed()
-  {
-    $this->expectException(\InvalidArgumentException::class);
+    // @group AddAttribute
+    public function testAddAttributeThrowEmptyDataPassed()
+    {
+        $this->expectException(\InvalidArgumentException::class);
 
-    $client = new EngageClient($this->key, $this->secret);
-    $data = $client->users->addAttribute($this->id, []);
-  }
+        $client = new EngageClient($this->key, $this->secret);
+        $data = $client->users->addAttribute($this->id, []);
+    }
 
-  // @group Track
-  public function testTrackShouldThrowNoParameter()
-  {
-    $this->expectException(\ArgumentCountError::class);
+    // @group Track
+    public function testTrackShouldThrowNoParameter()
+    {
+        $this->expectException(\ArgumentCountError::class);
 
-    $client = new EngageClient($this->key, $this->secret);
-    $data = $client->users->track();
-  }
+        $client = new EngageClient($this->key, $this->secret);
+        $data = $client->users->track();
+    }
 
-  // @group Track
-  public function testTrackThrowNoDataAtrrPassed()
-  {
-    $this->expectException(\InvalidArgumentException::class);
+    // @group Track
+    public function testTrackThrowNoDataAtrrPassed()
+    {
+        $this->expectException(\InvalidArgumentException::class);
 
-    $client = new EngageClient($this->key, $this->secret);
-    $data = $client->users->track($this->id, null);
-  }
+        $client = new EngageClient($this->key, $this->secret);
+        $data = $client->users->track($this->id, null);
+    }
 }


### PR DESCRIPTION
This PR adds a functional HTTP client to process the `addAttribute`, `identify`, and `track` resource handlers.
Added Unit tests for the `EngageClient` and `User` Resource, and user-configurable integration tests.

The package can be initialized and used as described below:
```php
<?php
use Engage\EngageClient;

$engage = new EngageClient('KEY', 'SECRET');
$users = $engage->users;
// track event
$resp = $users->track('id_x', [
      'event' => 'Withdrawal',
      'value' => 190.23
])

```